### PR TITLE
Cover case of user being null in user_or_null_converter method

### DIFF
--- a/twitter_openapi_python/twitter_openapi_python/utils/api.py
+++ b/twitter_openapi_python/twitter_openapi_python/utils/api.py
@@ -115,6 +115,8 @@ def tweet_entries_converter(
 
 
 def user_or_null_converter(user: models.UserUnion) -> Optional[models.User]:
+    if user is None:
+        return None
     if isinstance(user.actual_instance, models.User):
         return user.actual_instance
 


### PR DESCRIPTION
Twitter recently updated their followers endpoint, causing user to occasionally be null. This should cover the case when this happens.